### PR TITLE
api token fix

### DIFF
--- a/loan-broker/workflow.py
+++ b/loan-broker/workflow.py
@@ -12,15 +12,12 @@ from model.bank_model import LoanRequestModel, Credit
 
 logging.basicConfig(level=logging.INFO)
 
-base_url = os.getenv('DAPR_HTTP_ENDPOINT', 'http://localhost')
+dapr_http_endpoint = os.getenv('DAPR_HTTP_ENDPOINT', 'http://localhost')
+dapr_api_token = os.getenv('DAPR_API_TOKEN', '')
 target_credit_bureau_app_id = os.getenv('DAPR_CREDIT_BUREAU_APP_ID', '')
-target_credit_bureau_api_token = os.getenv('DAPR_CREDIT_BUREAU_API_TOKEN', '')
 target_union_vault_app_id = os.getenv('DAPR_UNION_VAULT_APP_ID', '')
-target_union_vault_api_token = os.getenv('DAPR_UNION_VAULT_API_TOKEN', '')
 target_titanium_trust_app_id = os.getenv('DAPR_TITANIUM_TRUST_APP_ID', '')
-target_titanium_trust_api_token = os.getenv('DAPR_TITANIUM_TRUST_API_TOKEN', '')
 target_riverstone_bank_app_id = os.getenv('DAPR_RIVERSTONE_BANK_APP_ID', '')
-target_riverstone_bank_api_token = os.getenv('DAPR_RIVERSTONE_BANK_API_TOKEN', '')
 
 
 
@@ -55,7 +52,7 @@ def riverstone_bank_quote(ctx, work_item: int):
     credit = Credit(score="500")
     loan_req = LoanRequestModel(amount="4000", term="6", credit=credit)
     # assign package to available delivery guy.
-    headers = {'dapr-app-id': target_riverstone_bank_app_id, 'dapr-api-token': target_riverstone_bank_api_token,
+    headers = {'dapr-app-id': target_riverstone_bank_app_id, 'dapr-api-token': dapr_api_token,
                'content-type': 'application/json'}
     # request/response
     try:
@@ -87,7 +84,7 @@ def titanium_trust_quote(ctx, work_item: int):
     credit = Credit(score="500")
     loan_req = LoanRequestModel(amount="4000", term="6", credit=credit)
     # assign package to available delivery guy.
-    headers = {'dapr-app-id': target_titanium_trust_app_id, 'dapr-api-token': target_titanium_trust_api_token,
+    headers = {'dapr-app-id': target_titanium_trust_app_id, 'dapr-api-token': dapr_api_token,
                'content-type': 'application/json'}
     # request/response
     try:
@@ -118,8 +115,7 @@ def titanium_trust_quote(ctx, work_item: int):
 def union_vault_quote(ctx, work_item: int):
     credit = Credit(score="500")
     loan_req = LoanRequestModel(amount="4000", term="6", credit=credit)
-    # assign package to available delivery guy.
-    headers = {'dapr-app-id': target_union_vault_app_id, 'dapr-api-token': target_union_vault_api_token,
+    headers = {'dapr-app-id': target_union_vault_app_id, 'dapr-api-token': dapr_api_token,
                'content-type': 'application/json'}
     # request/response
     try:

--- a/loan-broker/workflow.py
+++ b/loan-broker/workflow.py
@@ -57,7 +57,7 @@ def riverstone_bank_quote(ctx, work_item: int):
     # request/response
     try:
         result = requests.post(
-            url='%s/v1.0/loan/request' % base_url,
+            url='%s/v1.0/loan/request' % dapr_http_endpoint,
             json=loan_req.model_dump(),
 
             headers=headers
@@ -89,7 +89,7 @@ def titanium_trust_quote(ctx, work_item: int):
     # request/response
     try:
         result = requests.post(
-            url='%s/v1.0/loan/request' % base_url,
+            url='%s/v1.0/loan/request' % dapr_http_endpoint,
             json=loan_req.model_dump(),
 
             headers=headers
@@ -120,7 +120,7 @@ def union_vault_quote(ctx, work_item: int):
     # request/response
     try:
         result = requests.post(
-            url='%s/v1.0/loan/request' % base_url,
+            url='%s/v1.0/loan/request' % dapr_http_endpoint,
             json=loan_req.model_dump(),
 
             headers=headers


### PR DESCRIPTION
Hey Rosius- slight bit of clarification. When you call other apps via service invocation or pubsub, you can use the API token of the calling app. In this case, your workflow app has an api token and no matter what calls it makes, it uses one api token for making requests to catalyst. I updated your sample to reflect this just so you can see what I am describing. LMK if you have questions. 

For clarity too, when you use the api token of the app you are calling, in catalyst it will look like the app is calling itself